### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /Lcd/build/
 /FXyz-Core/build/
 /FXyz-Client/build/
+/.gradle


### PR DESCRIPTION
Temporary files in `.gradle` folder should not be committed. Ony `gradle` folder should be committed if the gradle wrapper is used.