### PR TITLE
Warnings removal for Maya importer

### DIFF
--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/Loader.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/Loader.java
@@ -38,7 +38,6 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -124,9 +123,9 @@ class Loader {
     // Joint rootJoint; //NO_JOINTS
     Map<MNode, Node> loaded = new HashMap<>();
 
-    Map<Float, List<KeyValue>> keyFrameMap = new TreeMap();
+    Map<Float, List<KeyValue>> keyFrameMap = new TreeMap<>();
 
-    Map<Node, MNode> meshParents = new HashMap();
+    Map<Node, MNode> meshParents = new HashMap<>();
 
     private MFloat3Array mVerts;
     // Optionally force per-face per-vertex normal generation
@@ -303,7 +302,7 @@ class Loader {
             PolygonMeshView targetMayaMeshView = (PolygonMeshView) targetMayaMeshNode;
             
             PolygonMesh sourceMesh = (PolygonMesh) sourceMayaMeshView.getMesh();
-            SkinningMesh targetMesh = new SkinningMesh(sourceMesh, weights, bindPreMatrix, bindGlobalMatrix, jointNodes, new ArrayList(jointForest));
+            SkinningMesh targetMesh = new SkinningMesh(sourceMesh, weights, bindPreMatrix, bindGlobalMatrix, jointNodes, new ArrayList<>(jointForest));
             targetMayaMeshView.setMesh(targetMesh);
 
             final SkinningMeshTimer skinningMeshTimer = new SkinningMeshTimer(targetMesh);
@@ -941,7 +940,7 @@ class Loader {
     void convertAnimCurveRange(
             MNode n, final DoubleProperty property,
             boolean convertAnglesToDegrees) {
-        Collection inputs = n.getConnectionsTo("i");
+        List<MConnection> inputs = n.getConnectionsTo("i");
         boolean isDrivenAnimCurve = (inputs.size() > 0);
         boolean useTangentInterpolator = true;  // use the NEW tangent interpolator
 
@@ -991,7 +990,7 @@ class Loader {
                 (n.isInstanceOf(animCurveUA) || n.isInstanceOf(animCurveUL) ||
                         n.isInstanceOf(animCurveUT) || n.isInstanceOf(animCurveUU));
 
-        List<KeyFrame> drivenKeys = new LinkedList();
+        List<KeyFrame> drivenKeys = new LinkedList<>();
 
         // Many incoming animation curves start at keyframe 1; to
         // correctly interpret these we need to subtract off one frame
@@ -1005,7 +1004,7 @@ class Loader {
         float[] prevOutTan = new float[3];  // for orig interpolator
         float[] curOutTan = new float[3];  // for tan interpolator
         float[] curInTan = new float[3];  // for both interpolators
-        Collection toPaths = n.getPathsConnectingFrom("o");
+        List<MPath> toPaths = n.getPathsConnectingFrom("o");
         String keyName = null;
         String targetName = null;
         for (Object obj : toPaths) {

--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MConnection.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MConnection.java
@@ -66,15 +66,11 @@ public class MConnection {
         return sourcePath.hashCode() ^ targetPath.hashCode();
     }
 
-    public static final Comparator SOURCE_PATH_COMPARATOR = (o1, o2) -> {
-        MConnection c1 = (MConnection) o1;
-        MConnection c2 = (MConnection) o2;
-        return c1.getSourcePath().compareTo(c2.getSourcePath());
+    public static final Comparator<? super MConnection> SOURCE_PATH_COMPARATOR = (o1, o2) -> {
+        return o1.getSourcePath().compareTo(o2.getSourcePath());
     };
 
-    public static final Comparator TARGET_PATH_COMPARATOR = (o1, o2) -> {
-        MConnection c1 = (MConnection) o1;
-        MConnection c2 = (MConnection) o2;
-        return c1.getTargetPath().compareTo(c2.getTargetPath());
+    public static final Comparator<? super MConnection> TARGET_PATH_COMPARATOR = (o1, o2) -> {
+        return o1.getTargetPath().compareTo(o2.getTargetPath());
     };
 }

--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MEnv.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MEnv.java
@@ -493,9 +493,9 @@ public class MEnv {
     }
 
 
-    private final Set<MNode> nodes = new LinkedHashSet();
-    private final Map<String, MNodeType> nodeTypes = new HashMap();
-    private final Map<String, MDataType> dataTypes = new HashMap();
+    private final Set<MNode> nodes = new LinkedHashSet<>();
+    private final Map<String, MNodeType> nodeTypes = new HashMap<>();
+    private final Map<String, MDataType> dataTypes = new HashMap<>();
 
     public Collection<MNode> getNodes() {
         return nodes;
@@ -748,6 +748,7 @@ public class MEnv {
             addAttribute(new MAttribute(env, "spread", "spr", env.findDataType("double")));
         }
 
+        @Override
         protected void initNode(MNode result) {
             MInt e = (MInt)result.getAttr("emt");
             e.set(1);
@@ -2700,8 +2701,8 @@ Less or Equal */
         addNodeType(new nxRigidBody(this));
     }
 
-    Map<MNode, Set<MConnection> > connections = new HashMap();
-    Map<MNode, Set<MConnection> > invConnections = new HashMap();
+    Map<MNode, Set<MConnection> > connections = new HashMap<>();
+    Map<MNode, Set<MConnection> > invConnections = new HashMap<>();
     
     public void connectAttr(String src,  String target) {
         MPath srcPath = new MPath(this, src);
@@ -2717,14 +2718,14 @@ Less or Equal */
         MConnection conn = new MConnection(srcPath, targetPath);
         Set<MConnection> set = connections.get(srcNode);
         if (set == null) {
-            set = new HashSet();
+            set = new HashSet<>();
             connections.put(srcNode, set);
         }
         set.add(conn);
 
         set = invConnections.get(targetNode);
         if (set == null) {
-            set = new HashSet();
+            set = new HashSet<>();
             invConnections.put(targetNode, set);
         }
         set.add(conn);
@@ -2744,7 +2745,7 @@ Less or Equal */
 
     public Set<MConnection> getConnectionsTo(MPath path, boolean checkSubPaths) {
 
-        Set<MConnection> result = new HashSet();
+        Set<MConnection> result = new HashSet<>();
         getConnectionsTo(path, checkSubPaths, result);
         return result;
     }
@@ -2784,7 +2785,7 @@ Less or Equal */
     }
 
     public Set<MPath> getPathsConnectingTo(MPath path, boolean checkSubPaths) {
-        Set<MPath> result = new HashSet();
+        Set<MPath> result = new HashSet<>();
         Set<MConnection> conns = getConnectionsTo(path, checkSubPaths);
         for (MConnection conn : conns) {
             result.add(conn.getSourcePath());
@@ -2805,7 +2806,7 @@ Less or Equal */
     }
 
     public Set<MConnection> getConnectionsFrom(MPath path, boolean checkSubPaths) {
-        Set<MConnection> result = new HashSet();
+        Set<MConnection> result = new HashSet<>();
         Set<MConnection> conns = connections.get(path.getTargetNode());
         if (conns != null) {
             for (MConnection conn : conns) {
@@ -2836,7 +2837,7 @@ Less or Equal */
     }
 
     public Set<MPath> getPathsConnectingFrom(MPath path, boolean checkSubPaths) {
-        Set<MPath> result = new HashSet();
+        Set<MPath> result = new HashSet<>();
         Set<MConnection> conns = getConnectionsFrom(path, checkSubPaths);
         for (MConnection conn : conns) {
             result.add(conn.getTargetPath());

--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MNode.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MNode.java
@@ -47,7 +47,7 @@ public class MNode extends MObject {
 
     MNodeType nodeType;
     boolean hasLocalType = false;
-    Map<String, MData> values = new HashMap();
+    Map<String, MData> values = new HashMap<>();
 
     public void createInstance(String instanceName) {
     }
@@ -66,8 +66,8 @@ public class MNode extends MObject {
         return nodeType;
     }
 
-    List<MNode> parentNodes = new ArrayList();
-    List<MNode> childNodes = new ArrayList();
+    List<MNode> parentNodes = new ArrayList<>();
+    List<MNode> childNodes = new ArrayList<>();
 
     public void addAttr(
             String longName,
@@ -149,7 +149,7 @@ public class MNode extends MObject {
 
     public String getFullName() {
         String result = "";
-        LinkedList<MNode> path = new LinkedList();
+        LinkedList<MNode> path = new LinkedList<>();
         MNode n = this;
         while (true) {
             path.addFirst(n);
@@ -170,7 +170,7 @@ public class MNode extends MObject {
     /** Returns a list of MConnections connecting out of the given attribute, sorted by the source path. */
     public List<MConnection> getConnectionsFrom(String attr) {
         Set<MConnection> c = getEnv().getConnectionsFrom(new MPath(this, "." + attr));
-        List<MConnection> result = new ArrayList();
+        List<MConnection> result = new ArrayList<>();
         result.addAll(c);
         Collections.sort(result, MConnection.SOURCE_PATH_COMPARATOR);
         return result;
@@ -179,7 +179,7 @@ public class MNode extends MObject {
     /** Returns a list of MPaths connecting out of the given attribute. */
     public List<MPath> getPathsConnectingFrom(String attr) {
         Set<MPath> c = getEnv().getPathsConnectingFrom(new MPath(this, "." + attr));
-        List<MPath> result = new ArrayList();
+        List<MPath> result = new ArrayList<>();
         result.addAll(c);
         return result;
     }
@@ -191,7 +191,7 @@ public class MNode extends MObject {
     /** Returns a list of MConnections connecting into the given attribute, sorted by the target path. */
     public List<MConnection> getConnectionsTo(String attr) {
         Set<MConnection> c = getEnv().getConnectionsTo(new MPath(this, "." + attr));
-        List<MConnection> result = new ArrayList();
+        List<MConnection> result = new ArrayList<>();
         result.addAll(c);
         Collections.sort(result, MConnection.TARGET_PATH_COMPARATOR);
         return result;
@@ -200,7 +200,7 @@ public class MNode extends MObject {
     /** Returns a list of MPaths connecting into the given attribute. */
     public List<MPath> getPathsConnectingTo(String attr) {
         Set<MPath> c = getEnv().getPathsConnectingTo(new MPath(this, "." + attr));
-        List<MPath> result = new ArrayList();
+        List<MPath> result = new ArrayList<>();
         result.addAll(c);
         return result;
     }

--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MNodeType.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MNodeType.java
@@ -39,11 +39,11 @@ import java.util.List;
 import java.util.Map;
 
 public abstract class MNodeType extends MObject {
-    Map<String, MAttribute> attributes = new HashMap();
-    Map<String, MAttribute> attributesByShortName = new HashMap();
-    List<MNodeType> superTypes = new ArrayList();
+    Map<String, MAttribute> attributes = new HashMap<>();
+    Map<String, MAttribute> attributesByShortName = new HashMap<>();
+    List<MNodeType> superTypes = new ArrayList<>();
 
-    Map<String, String> canonicalNames = new HashMap();
+    Map<String, String> canonicalNames = new HashMap<>();
 
     public Collection<MAttribute> getAttributes() {
         return attributes.values();

--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MPath.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MPath.java
@@ -44,9 +44,9 @@ import org.fxyz3d.importers.maya.values.MIntArray;
 
 // ry => r[1];
 
-public class MPath implements Comparable {
+public class MPath implements Comparable<MPath> {
 
-    static abstract class Component implements Comparable {
+    static abstract class Component implements Comparable<Component> {
         public MData apply(MData data) {
             return null;
         }
@@ -94,7 +94,7 @@ public class MPath implements Comparable {
         }
 
         @Override
-        public int compareTo(Object arg) {
+        public int compareTo(Component arg) {
             if (arg instanceof Index) {
                 return index - ((Index) arg).index;
             }
@@ -142,7 +142,7 @@ public class MPath implements Comparable {
         }
 
         @Override
-        public int compareTo(Object arg) {
+        public int compareTo(Component arg) {
             if (arg instanceof Slice) {
                 Slice other = (Slice) arg;
                 int diff = start - other.start;
@@ -201,7 +201,7 @@ public class MPath implements Comparable {
         }
 
         @Override
-        public int compareTo(Object arg) {
+        public int compareTo(Component arg) {
             if (arg instanceof Select) {
                 return name.compareTo(((Select) arg).name);
             }
@@ -217,7 +217,7 @@ public class MPath implements Comparable {
     // A Path always exists within the context of a given node
     MNode node;
 
-    List<Component> components = new ArrayList();
+    List<Component> components = new ArrayList<>();
 
     private void add(Component comp) {
         components.add(comp);
@@ -304,8 +304,7 @@ public class MPath implements Comparable {
     }
 
     @Override
-    public int compareTo(Object arg) {
-        MPath other = (MPath) arg;
+    public int compareTo(MPath other) {
         if (node != other.node) {
             return node.hashCode() - other.node.hashCode();
         }

--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MayaImporter.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/MayaImporter.java
@@ -57,7 +57,7 @@ public class MayaImporter extends Importer {
     // javafx.scene.shape3d.Character rootCharacter = new javafx.scene.shape3d.Character();
     MayaGroup root = new MayaGroup();
     Timeline timeline;
-    Set<Node> meshParents = new HashSet();
+    Set<Node> meshParents = new HashSet<>();
 
     // NO_JOINTS
     // public javafx.scene.shape3d.Character getRootCharacter() {

--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/parser/MParser.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/parser/MParser.java
@@ -466,7 +466,7 @@ public class MParser {
 
     private void doSetAttr() {
         String target = null;
-        List<String> value = new ArrayList();
+        List<String> value = new ArrayList<>();
         @SuppressWarnings("UnusedDeclaration") String type = null;
         int size = -1;
         for (int i = 0; i < curArgs.size(); i++) {

--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/types/MCompoundType.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/types/MCompoundType.java
@@ -42,8 +42,8 @@ import org.fxyz3d.importers.maya.values.impl.MCompoundImpl;
 
 public class MCompoundType extends MDataType {
 
-    Map<String, Field> fields = new HashMap();
-    List<Field> fieldArray = new ArrayList();
+    Map<String, Field> fields = new HashMap<>();
+    List<Field> fieldArray = new ArrayList<>();
 
     public MCompoundType(MEnv env, String name) {
         super(env, name);

--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/values/impl/MArrayImpl.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/values/impl/MArrayImpl.java
@@ -44,7 +44,7 @@ public class MArrayImpl extends MDataImpl implements MArray {
     public static final boolean DEBUG = MayaImporter.DEBUG;
     public static final boolean WARN = MayaImporter.WARN;
 
-    List<MData> data = new ArrayList();
+    List<MData> data = new ArrayList<>();
 
     static class Parser {
         private final MArray array;
@@ -127,6 +127,7 @@ public class MArrayImpl extends MDataImpl implements MArray {
         return (MArrayType) getType();
     }
 
+    @Override
     public List<MData> get() {
         return data;
     }

--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/values/impl/MAttributeAliasImpl.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/maya/values/impl/MAttributeAliasImpl.java
@@ -43,21 +43,21 @@ import org.fxyz3d.importers.maya.values.MAttributeAlias;
 
 public class MAttributeAliasImpl extends MDataImpl implements MAttributeAlias {
 
-    Map<String, String> map = new TreeMap();
+    Map<String, String> map = new TreeMap<>();
 
     public MAttributeAliasImpl(MAttributeAliasType type) {
         super(type);
     }
 
     @Override
-    public Map getMapping() {
+    public Map<String, String> getMapping() {
         return map;
     }
 
     @Override
     public void parse(Iterator<String> values) {
         int count = 0;
-        List<String> list = new ArrayList();
+        List<String> list = new ArrayList<>();
         while (values.hasNext()) {
             String str = values.next();
             int start = str.indexOf("\"");


### PR DESCRIPTION
Warnings cleanup for `org.fxyz3d.importers.maya`.

Unused and serialization warnings were not touched. In `MParser` there is a `@SuppressWarnings("UnusedDeclaration")`, which is IntelliJ-specific. In Eclipse it would be `@SuppressWarnings("unused")`. I left it out as part of the "unused" package.