### PR TITLE
#55 Don’t publish JavaFX classifier

### DIFF
--- a/FXyz-Client/gradle/publishing.gradle
+++ b/FXyz-Client/gradle/publishing.gradle
@@ -100,11 +100,9 @@ publishing {
 
             pom.withXml {
                 def root = asNode()
-                root.dependencies.'*'.findAll() {
-                    it.groupId.text() == 'org.openjfx'
-                }.each {
-                    it.remove(it.classifier)
-                }
+                root.dependencies.'*'
+                        .findAll() { it.groupId.text() == 'org.openjfx' }
+                        .each { it.remove(it.classifier) }
                 root.appendNode 'description', publishing.desc
                 root.children().last() + pomConfig
             }

--- a/FXyz-Client/gradle/publishing.gradle
+++ b/FXyz-Client/gradle/publishing.gradle
@@ -100,6 +100,11 @@ publishing {
 
             pom.withXml {
                 def root = asNode()
+                root.dependencies.'*'.findAll() {
+                    it.groupId.text() == 'org.openjfx'
+                }.each {
+                    it.remove(it.classifier)
+                }
                 root.appendNode 'description', publishing.desc
                 root.children().last() + pomConfig
             }

--- a/FXyz-Core/gradle/publishing.gradle
+++ b/FXyz-Core/gradle/publishing.gradle
@@ -100,6 +100,11 @@ publishing {
 
             pom.withXml {
                 def root = asNode()
+                root.dependencies.'*'.findAll() { 
+                    it.groupId.text() == 'org.openjfx' 
+                }.each { 
+                    it.remove(it.classifier) 
+                }
                 root.appendNode 'description', publishing.desc
                 root.children().last() + pomConfig
             }

--- a/FXyz-Core/gradle/publishing.gradle
+++ b/FXyz-Core/gradle/publishing.gradle
@@ -100,11 +100,9 @@ publishing {
 
             pom.withXml {
                 def root = asNode()
-                root.dependencies.'*'.findAll() { 
-                    it.groupId.text() == 'org.openjfx' 
-                }.each { 
-                    it.remove(it.classifier) 
-                }
+                root.dependencies.'*'
+                        .findAll() { it.groupId.text() == 'org.openjfx' }
+                        .each { it.remove(it.classifier) }
                 root.appendNode 'description', publishing.desc
                 root.children().last() + pomConfig
             }

--- a/FXyz-Importers/gradle/publishing.gradle
+++ b/FXyz-Importers/gradle/publishing.gradle
@@ -100,11 +100,9 @@ publishing {
 
             pom.withXml {
                 def root = asNode()
-                root.dependencies.'*'.findAll() {
-                    it.groupId.text() == 'org.openjfx'
-                }.each {
-                    it.remove(it.classifier)
-                }
+                root.dependencies.'*'
+                        .findAll() { it.groupId.text() == 'org.openjfx' }
+                        .each { it.remove(it.classifier) }
                 root.appendNode 'description', publishing.desc
                 root.children().last() + pomConfig
             }

--- a/FXyz-Importers/gradle/publishing.gradle
+++ b/FXyz-Importers/gradle/publishing.gradle
@@ -100,6 +100,11 @@ publishing {
 
             pom.withXml {
                 def root = asNode()
+                root.dependencies.'*'.findAll() {
+                    it.groupId.text() == 'org.openjfx'
+                }.each {
+                    it.remove(it.classifier)
+                }
                 root.appendNode 'description', publishing.desc
                 root.children().last() + pomConfig
             }


### PR DESCRIPTION
(This is still work in progress to allow publishing to Maven Central)

This PR removes the classifier from the pom file of core/client/imports artifacts. This is required to avoid adding platform dependencies from where the library was published to other platforms that consume the library. 