### PR TITLE
Initial MtlReader refactoring

### DIFF
--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/obj/MtlReader.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/obj/MtlReader.java
@@ -65,7 +65,7 @@ public class MtlReader {
         try (Stream<String> line = Files.lines(Paths.get(new URI(fileUrl)))) {
             line.map(String::trim)
                 .filter(l -> !l.isEmpty() && !l.startsWith("#"))
-                .forEach(this::parse2);
+                .forEach(this::parse);
         } catch (IOException | URISyntaxException e) {
             e.printStackTrace();
         }
@@ -101,7 +101,7 @@ public class MtlReader {
             entry("refl ",      (l, m) -> m.parseIgnore("Reflection map (refl)")),
             entry("map_aat ",   (l, m) -> m.parseIgnore("Anti-aliasing (map_aat)")));
 
-    private void parse2(String line) {
+    private void parse(String line) {
         for (Entry<String, BiConsumer<String, MtlReader>> parser : PARSERS.entrySet()) {
             String identifier = parser.getKey();
             if (line.startsWith(identifier)) {
@@ -128,7 +128,7 @@ public class MtlReader {
         currentMaterial = new PhongMaterial();
         readProperties.clear();
         materials.put(value, currentMaterial);
-        ObjImporter.log("Reading material " + value);
+        ObjImporter.log(System.lineSeparator() + "Reading material " + value);
     }
     
     private void parseDiffuseReflectivity(String value) {


### PR DESCRIPTION
Changes to `MtlReader`:

* Now reading with a stream, though it seems that mtl files are always short enough for sequential processing. Is this reasonable?
* Trying an `enum` approach as opposed to the `Map<Predicate, Consumer>`  approach in `ObjImporter` for the parser. Not sure if it's better or worse.
* Added missing properties, most of which are being ignored. Bump map and Specular map are treated now, but didn't test them.
* Now filtering empty lines and comments during reading. Do we really need to parse these like other lines? Same question goes for `ObjImporter`.
* What to do when reading a material which already exists? Completely replace it, ignore it, update by adding/overriding existing values, or throw an error?
* What to do when reading a property for a material which was already read? e.g.,
  ```
  newmtl mat
  Kd ...
  Ks ...
  Kd ... // again
  ```
  Replace, ignore, or throw an error?