### PR TITLE
Replace Nashorn engine with graaljs

### DIFF
--- a/FXyz-Client/src/main/java/org/fxyz3d/client/FXyzClient.java
+++ b/FXyz-Client/src/main/java/org/fxyz3d/client/FXyzClient.java
@@ -466,6 +466,7 @@ public class FXyzClient extends Application {
     }
 
     public static void main(String[] args) {
+        System.setProperty("polyglot.js.nashorn-compat", "true");
         launch(args);
     }
 }

--- a/FXyz-Samples/build.gradle
+++ b/FXyz-Samples/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation ('org.reactfx:reactfx:2.0-M5')
     implementation ('org.fxmisc.easybind:easybind:1.0.4-SNAPSHOT')
     implementation ('org.jfxtras:jfxtras-controls:9.0-r1')
+    implementation "org.graalvm.js:js:20.2.0"
+    implementation "org.graalvm.js:js-scriptengine:20.2.0"
 }
 
 compileJava {

--- a/FXyz-Samples/src/main/java/module-info.java
+++ b/FXyz-Samples/src/main/java/module-info.java
@@ -41,8 +41,7 @@ module org.fxyz3d.FXyz.Samples {
     requires jfxtras.controls;
     requires jfxtras.fxml;
     requires java.scripting;
-    requires jdk.scripting.nashorn;
-    
+
     opens org.fxyz3d.controls to javafx.fxml;
     provides org.fxyz3d.FXyzSamplerProject with org.fxyz3d.samples.FXyzProject;
     

--- a/FXyz-Samples/src/main/java/org/fxyz3d/controls/ScriptFunction1DControl.java
+++ b/FXyz-Samples/src/main/java/org/fxyz3d/controls/ScriptFunction1DControl.java
@@ -1,7 +1,7 @@
 /**
  * ScriptFunction1DControl.java
  *
- * Copyright (c) 2013-2016, F(X)yz
+ * Copyright (c) 2013-2020, F(X)yz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,6 +47,9 @@ import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.VBox;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
@@ -64,8 +67,11 @@ public class ScriptFunction1DControl extends ControlBase<Property<Function<Numbe
     
     public ScriptFunction1DControl(Property<Function<Number,Number>> prop, final Collection<String> items, boolean subControl) {
         super("/org/fxyz3d/controls/ScriptFunction1DControl.fxml", prop);
-        
-       Double x=1d;
+
+        Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        bindings.put("polyglot.js.allowAllAccess", true);
+
+        Double x=1d;
         res1.setText("x: {"+x+"}");
                     
         selection.getItems().setAll(items);
@@ -150,7 +156,7 @@ public class ScriptFunction1DControl extends ControlBase<Property<Function<Numbe
     private Label res2;
     @FXML
     private ComboBox<String> selection;
-    private final ScriptEngine engine = new ScriptEngineManager().getEngineByName("nashorn");
+    private final ScriptEngine engine = new ScriptEngineManager().getEngineByName("graal.js");
     
     @FXML
     protected VBox subControls;

--- a/FXyz-Samples/src/main/java/org/fxyz3d/controls/ScriptFunction2DControl.java
+++ b/FXyz-Samples/src/main/java/org/fxyz3d/controls/ScriptFunction2DControl.java
@@ -1,7 +1,7 @@
 /**
  * ScriptFunction2DControl.java
  *
- * Copyright (c) 2013-2016, F(X)yz
+ * Copyright (c) 2013-2020, F(X)yz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -48,6 +48,9 @@ import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.VBox;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
@@ -65,7 +68,10 @@ public class ScriptFunction2DControl extends ControlBase<Property<Function<Point
     
     public ScriptFunction2DControl(Property<Function<Point2D,Number>> prop, final Collection<String> items, boolean subControl) {
         super("/org/fxyz3d/controls/ScriptFunction2DControl.fxml", prop);
-        
+
+        Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        bindings.put("polyglot.js.allowAllAccess", true);
+
         Point2D p=new Point2D(1,2);
         res1.setText("p: {"+p.getX()+","+p.getY()+"}");
                     
@@ -149,7 +155,7 @@ public class ScriptFunction2DControl extends ControlBase<Property<Function<Point
     private Label res2;
     @FXML
     private ComboBox<String> selection;
-    private final ScriptEngine engine = new ScriptEngineManager().getEngineByName("nashorn");
+    private final ScriptEngine engine = new ScriptEngineManager().getEngineByName("graal.js");
     
     @FXML
     protected VBox subControls;

--- a/FXyz-Samples/src/main/java/org/fxyz3d/controls/ScriptFunction3DControl.java
+++ b/FXyz-Samples/src/main/java/org/fxyz3d/controls/ScriptFunction3DControl.java
@@ -1,7 +1,7 @@
 /**
  * ScriptFunction3DControl.java
  *
- * Copyright (c) 2013-2016, F(X)yz
+ * Copyright (c) 2013-2020, F(X)yz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -47,6 +47,9 @@ import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.VBox;
+
+import javax.script.Bindings;
+import javax.script.ScriptContext;
 import javax.script.ScriptEngine;
 import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
@@ -65,7 +68,10 @@ public class ScriptFunction3DControl extends ControlBase<Property<Function<Point
     
     public ScriptFunction3DControl(Property<Function<Point3D,Number>> prop, final Collection<String> items, boolean subControl) {
         super("/org/fxyz3d/controls/ScriptFunction3DControl.fxml", prop);
-        
+
+        Bindings bindings = engine.getBindings(ScriptContext.ENGINE_SCOPE);
+        bindings.put("polyglot.js.allowAllAccess", true);
+
         Point3D p=new Point3D(1f,2f,3f);
         res1.setText("p: {"+p.x+","+p.y+","+p.z+"}");
                     
@@ -151,7 +157,7 @@ public class ScriptFunction3DControl extends ControlBase<Property<Function<Point
     private Label res2;
     @FXML
     private ComboBox<String> selection;
-    private final ScriptEngine engine = new ScriptEngineManager().getEngineByName("nashorn");
+    private final ScriptEngine engine = new ScriptEngineManager().getEngineByName("graal.js");
     
     @FXML
     protected VBox subControls;

--- a/FXyz-Samples/src/main/java/org/fxyz3d/samples/shapes/GroupOfTexturedMeshSample.java
+++ b/FXyz-Samples/src/main/java/org/fxyz3d/samples/shapes/GroupOfTexturedMeshSample.java
@@ -1,7 +1,7 @@
 /**
  * GroupOfTexturedMeshSample.java
  *
- * Copyright (c) 2013-2016, F(X)yz
+ * Copyright (c) 2013-2020, F(X)yz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -57,6 +57,10 @@ import org.fxyz3d.tools.NormalMap;
  * @author Jason Pollastrini aka jdub1581
  */
 public abstract class GroupOfTexturedMeshSample extends ShapeBaseSample<Group>{
+
+    static {
+        TriangleMeshHelper.PARALLEL_ALLOWED = false;
+    }
 
     public GroupOfTexturedMeshSample(){
         sectionType.addListener((obs,s0,s1)->{

--- a/FXyz-Samples/src/main/java/org/fxyz3d/samples/shapes/TexturedMeshSample.java
+++ b/FXyz-Samples/src/main/java/org/fxyz3d/samples/shapes/TexturedMeshSample.java
@@ -1,7 +1,7 @@
 /**
  * TexturedMeshSample.java
  *
- * Copyright (c) 2013-2016, F(X)yz
+ * Copyright (c) 2013-2020, F(X)yz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,6 +55,10 @@ import org.fxyz3d.tools.NormalMap;
  * @author Jason Pollastrini aka jdub1581
  */
 public abstract class TexturedMeshSample extends ShapeBaseSample<TexturedMesh> {
+
+    static {
+        TriangleMeshHelper.PARALLEL_ALLOWED = false;
+    }
 
     //specific
     protected final Property<TriangleMeshHelper.SectionType> sectionType = new SimpleObjectProperty<TriangleMeshHelper.SectionType>(model, "secType", TriangleMeshHelper.SectionType.CIRCLE) {


### PR DESCRIPTION
Fixes #59 

I've done a quick hack for now to disable parallel streams when running from samples: graaljs doesn't allow multi-thread access when calling javascript...

```
Caused by: java.lang.IllegalStateException: Multi threaded access requested by thread Thread[ForkJoinPool.commonPool-worker-9,5,main] but is not allowed for language(s) js.
        at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotEngineException.illegalState(PolyglotEngineException.java:132)
        at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotContextImpl.throwDeniedThreadAccess(PolyglotContextImpl.java:660)
...
       at com.oracle.truffle.js.javaadapters.java.util.function.Function.apply(Unknown Source)
        at org.fxyz3d.core@0.5.3/org.fxyz3d.shapes.primitives.helper.TriangleMeshHelper.mapDensity(TriangleMeshHelper.java:293)
        at org.fxyz3d.core@0.5.3/org.fxyz3d.shapes.primitives.helper.TriangleMeshHelper.lambda$updateFacesWithDensityMap$17(TriangleMeshHelper.java:477)

```
Thoughts and feedback are wellcome