### PR TITLE
Organize build

### DIFF
--- a/FXyz-Client/build.gradle
+++ b/FXyz-Client/build.gradle
@@ -16,10 +16,10 @@ if (!hasProperty('mainClass')) {
 }
 
 dependencies {    
-    implementation ('org.controlsfx:controlsfx:11.0.1') {
+    api ('org.controlsfx:controlsfx:11.0.2') {
         exclude group:"org.openjfx"
     }
-    implementation 'org.reactfx:reactfx:2.0-M5'    
+    api 'org.reactfx:reactfx:2.0-M5'
 }
 
 javadoc {

--- a/FXyz-Client/gradle/publishing.gradle
+++ b/FXyz-Client/gradle/publishing.gradle
@@ -103,9 +103,6 @@ publishing {
                 root.dependencies.'*'
                         .findAll() { it.groupId.text() == 'org.openjfx' }
                         .each { it.remove(it.classifier) }
-                def repository = root.appendNode('repositories').appendNode('repository')
-                repository.appendNode('id', 'jzy3d')
-                repository.appendNode('url', 'http://maven.jzy3d.org/releases')
                 root.appendNode 'description', publishing.desc
                 root.children().last() + pomConfig
             }

--- a/FXyz-Core/build.gradle
+++ b/FXyz-Core/build.gradle
@@ -4,6 +4,9 @@ apply from: 'gradle/publishing.gradle'
 
 repositories {
     jcenter()
+    maven {
+        url = "http://maven.jzy3d.org/releases"
+    }
 }
 
 sourceCompatibility = '1.9'
@@ -12,4 +15,12 @@ targetCompatibility = '1.9'
 javadoc {
     options.addBooleanOption("Xdoclint:none").setValue(true);
     options.addBooleanOption("javafx").setValue(true);
+}
+
+dependencies {
+    api ('eu.mihosoft.vrl.jcsg:jcsg:0.5.7') { transitive = false }
+    api 'eu.mihosoft.vvecmath:vvecmath:0.4.0'
+    api 'org.orbisgis:poly2tri-core:0.1.2'
+    // A fork of JDT (Java Delaunay Triangulation) Core API from https://github.com/yonatang/JDT for Jzy3d
+    api 'org.jzy3d:jzy3d-jdt-core:1.0.2'
 }

--- a/FXyz-Core/src/main/java/module-info.java
+++ b/FXyz-Core/src/main/java/module-info.java
@@ -29,13 +29,13 @@
 
 module org.fxyz3d.core {
     requires transitive javafx.controls;
-    requires transitive javafx.swing;
+    requires static javafx.swing;
     requires java.desktop;
     requires java.logging;
-    requires jcsg;
-    requires vvecmath;
-    requires poly2tri.core;
-    requires jzy3d.jdt.core;
+    requires static jcsg;
+    requires static vvecmath;
+    requires static poly2tri.core;
+    requires static jzy3d.jdt.core;
 
     exports org.fxyz3d.geometry;
     exports org.fxyz3d.io;

--- a/FXyz-Importers/build.gradle
+++ b/FXyz-Importers/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 dependencies {
-    implementation project(':FXyz-Core')
+    api (project(':FXyz-Core')) { transitive = false }
 }
 
 javadoc {

--- a/FXyz-Importers/gradle/publishing.gradle
+++ b/FXyz-Importers/gradle/publishing.gradle
@@ -103,9 +103,6 @@ publishing {
                 root.dependencies.'*'
                         .findAll() { it.groupId.text() == 'org.openjfx' }
                         .each { it.remove(it.classifier) }
-                def repository = root.appendNode('repositories').appendNode('repository')
-                repository.appendNode('id', 'jzy3d')
-                repository.appendNode('url', 'http://maven.jzy3d.org/releases')
                 root.appendNode 'description', publishing.desc
                 root.children().last() + pomConfig
             }

--- a/FXyz-Samples/build.gradle
+++ b/FXyz-Samples/build.gradle
@@ -11,6 +11,9 @@ repositories {
     maven {
         url 'https://oss.sonatype.org/content/repositories/snapshots/'
     }
+    maven {
+        url = "http://maven.jzy3d.org/releases"
+    }
 }
 
 application {
@@ -25,7 +28,7 @@ dependencies {
     implementation project(':FXyz-Client')
     implementation project(':FXyz-Core')
     implementation project(':FXyz-Importers')
-    implementation ('org.controlsfx:controlsfx:11.0.1') {
+    implementation ('org.controlsfx:controlsfx:11.0.2') {
         exclude group:"org.openjfx"
     }
     implementation ('org.reactfx:reactfx:2.0-M5')

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Create a gradle project, edit the build.gradle file and add:
 ```
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.8'
+    id 'org.openjfx.javafxplugin' version '0.0.9'
 }
 
 mainClassName = 'org.fxyz3d.Sample'

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ ext {
     
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'maven'
     apply plugin: 'eclipse'
     apply plugin: 'org.openjfx.javafxplugin'
@@ -38,23 +39,16 @@ subprojects {
 
     repositories {
         jcenter()
-        maven {
-            url = "http://maven.jzy3d.org/releases"
-        }
     }
     
     dependencies {     
-        implementation ('eu.mihosoft.vrl.jcsg:jcsg:0.5.7') { transitive = false }
-        implementation 'eu.mihosoft.vvecmath:vvecmath:0.4.0'
-        implementation 'org.orbisgis:poly2tri-core:0.1.2'
-        // A fork of JDT (Java Delaunay Triangulation) Core API from https://github.com/yonatang/JDT for Jzy3d
-        implementation 'org.jzy3d:jzy3d-jdt-core:1.0.2'
         testImplementation 'org.junit.jupiter:junit-jupiter-api:5.3.1'
         testImplementation 'org.junit.jupiter:junit-jupiter-params:5.3.1'
         testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.3.1'
     }
-    
+
     javafx {
+        version = "15.0.1"
         modules = [ 'javafx.controls', 'javafx.fxml', 'javafx.swing' ]
     }
 


### PR DESCRIPTION
Fixes #113

Instead of having all dependencies in the parent build, move them to core. This allows, for instance, Importers to have only a clean dependency in the Core itself, and not in its transitive dependencies.