### PR TITLE
Update to slf4j 2.x for jpms compatibility

### DIFF
--- a/FXyz-Core/build.gradle
+++ b/FXyz-Core/build.gradle
@@ -7,5 +7,11 @@ repositories {
 dependencies {
     api ('eu.mihosoft.vrl.jcsg:jcsg:0.5.7') { transitive = false }
     api 'eu.mihosoft.vvecmath:vvecmath:0.4.0'
-    api 'org.orbisgis:poly2tri-core:0.1.2'
+    api ('org.orbisgis:poly2tri-core:0.1.2') {
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+    }
+    // Both eu.mihosoft.vrl.jcsg and org.orbisgis:poly2tri-core depend on this.
+    // Using 2.x instead to have a JPMS compatible version and "implementation"
+    // configuration to make it a runtimeElement when publishing.
+    implementation 'org.slf4j:slf4j-api:2.0.7'
 }

--- a/FXyz-Core/build.gradle
+++ b/FXyz-Core/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     // Both eu.mihosoft.vrl.jcsg and org.orbisgis:poly2tri-core depend on this.
     // Using 2.x instead to have a JPMS compatible version and "implementation"
     // configuration to make it a runtimeElement when publishing.
-    implementation 'org.slf4j:slf4j-api:2.0.7'
+    implementation "org.slf4j:slf4j-api:$slf4j_version"
 }

--- a/FXyz-Core/src/main/java/module-info.java
+++ b/FXyz-Core/src/main/java/module-info.java
@@ -25,7 +25,7 @@
  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */ 
+ */
 
 module org.fxyz3d.core {
     requires transitive javafx.controls;
@@ -35,6 +35,7 @@ module org.fxyz3d.core {
     requires static jcsg;
     requires static vvecmath;
     requires static poly2tri.core;
+    requires org.slf4j;
 
     exports org.fxyz3d.geometry;
     exports org.fxyz3d.io;

--- a/FXyz-Core/src/main/java/module-info.java
+++ b/FXyz-Core/src/main/java/module-info.java
@@ -1,7 +1,7 @@
 /**
  * F(X)yz
  *
- * Copyright (c) 2013-2018, F(X)yz
+ * Copyright (c) 2013-2023, F(X)yz
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/FXyz-Importers/build.gradle
+++ b/FXyz-Importers/build.gradle
@@ -2,5 +2,5 @@ ext.moduleName = 'org.fxyz3d.importers'
 
 dependencies {
     api (project(':FXyz-Core')) { transitive = false }
-    implementation (project(':FXyz-Core'))
+    testRuntimeOnly "org.slf4j:slf4j-api:$slf4j_version"
 }

--- a/FXyz-Importers/build.gradle
+++ b/FXyz-Importers/build.gradle
@@ -2,4 +2,5 @@ ext.moduleName = 'org.fxyz3d.importers'
 
 dependencies {
     api (project(':FXyz-Core')) { transitive = false }
+    implementation (project(':FXyz-Core'))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 group=org.fxyz3d
 version=0.5.5-SNAPSHOT
 javafx_version=17.0.2
+slf4j_version=2.0.7
 # disable publish of sha256, sha512
 systemProp.org.gradle.internal.publish.checksums.insecure=true


### PR DESCRIPTION
Closes https://github.com/FXyz/FXyz/issues/176

Somewhat related to https://github.com/FXyz/FXyz/issues/87

This upgrades slf4j to mark it as a runtime dependency, and also to 2.x which is jpms compatible and allows it to work smoothly with pure JLink downstream. Used `requires` instead of `requires transitive` on `org.slf4j` in `module-info.java` per [gradle docs conventions](https://docs.gradle.org/current/userguide/java_library_plugin.html#declaring_module_dependencies).

This will help with [Trinity](https://github.com/Birdasaur/Trinity) updates @Birdasaur