### PR TITLE
Obj: removed silent ignore of errors

### DIFF
--- a/FXyz-Importers/src/main/java/org/fxyz3d/importers/obj/ObjImporter.java
+++ b/FXyz-Importers/src/main/java/org/fxyz3d/importers/obj/ObjImporter.java
@@ -107,7 +107,7 @@ public class ObjImporter implements Importer {
         return SUPPORTED_EXT.equalsIgnoreCase(extension);
     }
 
-    private ObjModel read(URL url, boolean asPolygon) {
+    private ObjModel read(URL url, boolean asPolygon) throws IOException {
         log("Reading from URL: " + url + " as polygon: " + asPolygon);
 
         ObjModel model = asPolygon ? new PolyObjModel(url) : new ObjModel(url);
@@ -117,8 +117,6 @@ public class ObjImporter implements Importer {
                 .map(String::trim)
                 .filter(l -> !l.isEmpty() && !l.startsWith("#"))
                 .forEach(model::parseLine);
-        } catch (IOException e) {
-            e.printStackTrace();
         }
 
         model.addMesh(model.key);


### PR DESCRIPTION
`ObjImporter::load` is marked to throw an `IOException`, but the internal `ObjImporter::read` silently ignores any errors and never throws one. Invalid urls and missing files are happily parsed with no way to verify the result.

This PR passes the Exception up so users can be notified if e.g. a URL is not available.
